### PR TITLE
Put ticks around columns in insert statement to import_statistics

### DIFF
--- a/bin/DBImportConfig/import_stage.py
+++ b/bin/DBImportConfig/import_stage.py
@@ -622,7 +622,7 @@ class stage(object):
 		import_duration = None
 
 		for key, value in kwargs.items():
-			columnsPart.append(key)
+			columnsPart.append(f"`{key}`")
 			if value == True: value = 1
 			if value == False: value = 0
 			valuesPart.append(value)


### PR DESCRIPTION
In MariaDB 10.2.4, rows was added as a keyword (see https://mariadb.com/kb/en/reserved-words/). This causes the last step, save stage statistics, in dbimport to fail with a message like:
`mysql.connector.errors.ProgrammingError: 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'rows, sessions, get_source_tableschema_start, get_source_tableschema_stop, ge...' at line 1`

A fix that works for both older and newer versions of MariaDB would be to put \` around the columns in the insert statement created in `bin/DBImportConfig/import_stage.py::saveStageStatistics`.