### PR TITLE
Added support for Oracle ldap connection strings

### DIFF
--- a/bin/DBImportConfig/common_config.py
+++ b/bin/DBImportConfig/common_config.py
@@ -805,7 +805,8 @@ class config(object, metaclass=Singleton):
 
 			if self.jdbc_url.startswith('jdbc:oracle:thin:@ldap'):
 				pattern = r'@ldap://([^:/]+):(\d+)/([^,]+),'
-				if pattern is None:
+				r = re.search(pattern, self.jdbc_url)
+				if r is None:
 					logging.error("jdbc_string for ldap must be of the form jdbc:oracle:thin@ldap://<ldap_host>:<ldap_port>/<db>")
 					exit_after_function = True
 			else:

--- a/bin/DBImportConfig/common_config.py
+++ b/bin/DBImportConfig/common_config.py
@@ -803,31 +803,37 @@ class config(object, metaclass=Singleton):
 			self.jdbc_classpath_for_python = self.jdbc_classpath
 			self.jdbc_database = "-"
 
-			try:
-				self.jdbc_hostname = self.jdbc_url.split("(HOST=")[1].split(')')[0]
-			except:
-				logging.error("Cant determine hostname based on jdbc_string")
-				exit_after_function = True
+			if self.jdbc_url.startswith('jdbc:oracle:thin:@ldap'):
+				pattern = r'@ldap://([^:/]+):(\d+)/([^,]+),'
+				if pattern is None:
+					logging.error("jdbc_string for ldap must be of the form jdbc:oracle:thin@ldap://<ldap_host>:<ldap_port>/<db>")
+					exit_after_function = True
+			else:
+				try:
+					self.jdbc_hostname = self.jdbc_url.split("(HOST=")[1].split(')')[0]
+				except:
+					logging.error("Cant determine hostname based on jdbc_string")
+					exit_after_function = True
 
-			try:
-				self.jdbc_port = self.jdbc_url.split("(PORT=")[1].split(')')[0]
-			except:
-				logging.error("Cant determine port based on jdbc_string")
-				exit_after_function = True
+				try:
+					self.jdbc_port = self.jdbc_url.split("(PORT=")[1].split(')')[0]
+				except:
+					logging.error("Cant determine port based on jdbc_string")
+					exit_after_function = True
 
-			try:
-				self.jdbc_oracle_sid = self.jdbc_url.split("(SID=")[1].split(')')[0]
-			except:
-				self.jdbc_oracle_sid = None
+				try:
+					self.jdbc_oracle_sid = self.jdbc_url.split("(SID=")[1].split(')')[0]
+				except:
+					self.jdbc_oracle_sid = None
 
-			try:
-				self.jdbc_oracle_servicename = self.jdbc_url.split("(SERVICE_NAME=")[1].split(')')[0]
-			except:
-				self.jdbc_oracle_servicename = None
+				try:
+					self.jdbc_oracle_servicename = self.jdbc_url.split("(SERVICE_NAME=")[1].split(')')[0]
+				except:
+					self.jdbc_oracle_servicename = None
 
-			if self.jdbc_oracle_sid == None and self.jdbc_oracle_servicename == None:
-				logging.error("Cant find either SID or SERVICE_NAME in Oracle URL")
-				exit_after_function = True
+				if self.jdbc_oracle_sid == None and self.jdbc_oracle_servicename == None:
+					logging.error("Cant find either SID or SERVICE_NAME in Oracle URL")
+					exit_after_function = True
 
 
 		if self.jdbc_url.startswith( 'jdbc:mysql:'): 


### PR DESCRIPTION
We have some Oracle databases where they only support ldap connections and those connection strings have the following format: jdbc:oracle:thin:@ldap://oid:5000/mydb1,cn=OracleContext,dc=myco,dc=com 

The current code assumes a long service name format and so the above makes the code fail.
This PR adds support for LDAP connection strings as well.